### PR TITLE
Fixed personal id date validation

### DIFF
--- a/lib/src/czech_personal_id.dart
+++ b/lib/src/czech_personal_id.dart
@@ -17,21 +17,47 @@ bool isCzechPersonalIdNumber(String idNumber) {
 
 bool _isIdValid(final String id) {
   // validate year
-  final int yy = int.parse(id.trim().substring(0, 2));
-  if (!(yy >= 0 && yy <= 99)) return false;
+  final int y = int.parse(id.trim().substring(0, 2));
+  if (!(y >= 0 && y <= 99)) return false;
 
-  // month can be month of birth or +20 or +50 or +70
-  final int mm = int.parse(id.trim().substring(2, 4));
-  if (!((mm >= 1 && mm <= 12) ||
-      (mm - 20 >= 1 && mm - 20 <= 12) ||
-      (mm - 50 >= 1 && mm - 50 <= 12) ||
-      (mm - 70 >= 1 && mm - 70 <= 12))) return false;
+  // validate month
+  final int m = int.parse(id.trim().substring(2, 4));
+  final int mNormalized = _normalizeMonth(m);
+  if (mNormalized < 1 || mNormalized > 12) return false;
 
   // validate date
-  final int dd = int.parse(id.trim().substring(4, 6));
-  if (!(dd >= 1 && dd <= 31)) return false;
+  final int d = int.parse(id.trim().substring(4, 6));
+  return _isValidDate(d, mNormalized, 2000 + y);
+}
 
-  return true;
+bool _isValidDate(final int d, final int m, final int yyyy) {
+  try {
+    final dd = "$d".padLeft(2, "0");
+    final mm = "$m".padLeft(2, "0");
+    final yyyymmdd = "$yyyy$mm$dd";
+    final dt = new DateTime(yyyy, m, d);
+    return yyyymmdd == _toyyyymmdd(dt);
+  } catch (e) {
+    return false;
+  }
+}
+
+String _toyyyymmdd(final DateTime dt) {
+  final yyyy = dt.year.toString().padLeft(4, "0");
+  final mm = dt.month.toString().padLeft(2, "0");
+  final dd = dt.day.toString().padLeft(2, "0");
+  return "$yyyy$mm$dd";
+}
+
+/**
+* Returns normalized month that begin at 1.
+* [int mm] month of birth or +20 or +50 or +70
+*/
+int _normalizeMonth(final int mm) {
+  if (mm >= 70) return mm - 70;
+  if (mm >= 50) return mm - 50;
+  if (mm >= 20) return mm - 20;
+  return mm;
 }
 
 /**

--- a/lib/src/czech_personal_id.dart
+++ b/lib/src/czech_personal_id.dart
@@ -32,21 +32,11 @@ bool _isIdValid(final String id) {
 
 bool _isValidDate(final int d, final int m, final int yyyy) {
   try {
-    final dd = "$d".padLeft(2, "0");
-    final mm = "$m".padLeft(2, "0");
-    final yyyymmdd = "$yyyy$mm$dd";
     final dt = new DateTime(yyyy, m, d);
-    return yyyymmdd == _toyyyymmdd(dt);
+    return dt.month == m;
   } catch (e) {
     return false;
   }
-}
-
-String _toyyyymmdd(final DateTime dt) {
-  final yyyy = dt.year.toString().padLeft(4, "0");
-  final mm = dt.month.toString().padLeft(2, "0");
-  final dd = dt.day.toString().padLeft(2, "0");
-  return "$yyyy$mm$dd";
 }
 
 /**

--- a/test/czech_personal_id_test.dart
+++ b/test/czech_personal_id_test.dart
@@ -23,9 +23,12 @@ void main() {
       expect(isCzechPersonalIdNumber("410109/306"), isTrue);
       expect(isCzechPersonalIdNumber("320325/190"), isTrue);
       expect(isCzechPersonalIdNumber("305510/720"), isTrue);
-      expect(isCzechPersonalIdNumber("8002301010"), isTrue);
       expect(isCzechPersonalIdNumber("175510/720"), isTrue);
       expect(isCzechPersonalIdNumber("175510/7200"), isTrue);
+      expect(isCzechPersonalIdNumber("0002231010"), isTrue);
+      expect(isCzechPersonalIdNumber("1602291010"), isTrue); // leap year
+      expect(isCzechPersonalIdNumber("2002291016"), isTrue); // leap year
+      expect(isCzechPersonalIdNumber("5202291017"), isTrue); // leap year
     });
 
     test('Below inputs should be evaluated as invalid personal id numbers', () {
@@ -57,6 +60,14 @@ void main() {
           isCzechPersonalIdNumber("8811200976"), isFalse); // invalid structure
       expect(isCzechPersonalIdNumber("540101123"),
           isFalse); // from year 1954 every personal ID must be with control digit
+      expect(isCzechPersonalIdNumber("8002301010"), isFalse); // invalid date
+      expect(isCzechPersonalIdNumber("1705741015"), isFalse); // invalid date
+      expect(isCzechPersonalIdNumber("8702291114"), isFalse); // invalid date
+      expect(isCzechPersonalIdNumber("8700291114"), isFalse); // invalid date
+      expect(isCzechPersonalIdNumber("0006311019"), isFalse); // invalid date
+      expect(isCzechPersonalIdNumber("1702291019"), isFalse); // not a leap year
+      expect(isCzechPersonalIdNumber("2102291015"), isFalse); // not a leap year
+      expect(isCzechPersonalIdNumber("5302291016"), isFalse); // not a leap year
     });
   });
 }


### PR DESCRIPTION
Personal id date validation was mistakenly accepting invalid dates and ignoring leap years. This commit fix this bug.